### PR TITLE
fix: update recipe version

### DIFF
--- a/src/recipe.yml
+++ b/src/recipe.yml
@@ -1,6 +1,6 @@
 name: jjideenschmiede/github-upload-release-asset
 title: GitHub Upload Release Asset
-version: 1.0.1
+version: 1.0.0
 description: |
   Uploads a file as an asset to a GitHub release using the GitHub API.
   Requires a GitHub personal access token with repository permissions.


### PR DESCRIPTION
Reverts the version number in deployment configuration for the GitHub upload release asset from 1.0.1 back to 1.0.0. This correction is made in the YAML configuration file.
